### PR TITLE
Add musical overlay and gradient styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 body {
-  background: #111;
-  color: white;
+  background: linear-gradient(#eeeeee, #ffffff);
+  color: black;
   font-family: 'Open Sans', sans-serif;
   margin: 0;
   padding: 0;
@@ -39,8 +39,9 @@ h1 {
   padding: 15px;
   cursor: pointer;
   font-weight: bold;
-  color: white;
+  color: black;
   width: 100%;
+  background: linear-gradient(135deg, #eeeeee, #ffffff);
 }
 
 .bag-progress {
@@ -79,7 +80,8 @@ h1 {
   width: 80%;
   max-width: 600px;
   text-align: center;
-  color: white;
+  color: black;
+  background: linear-gradient(135deg, #eeeeee, #ffffff);
 }
 
 #items-list {
@@ -107,7 +109,7 @@ h1 {
   left: 0;
   width: 100%;
   padding: 10px;
-  background: #222;
+  background: linear-gradient(#eeeeee, #ffffff);
 }
 
 .progress {
@@ -154,4 +156,45 @@ h1 {
   .nav-buttons {
     margin-top: 20px;
   }
+}
+
+.music-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.boxmusic {
+  background: linear-gradient(135deg, #eeeeee, #ffffff);
+  opacity: 0.75;
+  padding: 20px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: bold;
+  color: black;
+  width: 80%;
+  max-width: 300px;
+}
+
+.music-progress {
+  width: 100%;
+  height: 10px;
+  background: #ccc;
+  border-radius: 5px;
+  overflow: hidden;
+  margin-top: 5px;
+}
+
+.music-progress-bar {
+  height: 100%;
+  background: green;
+  width: 0%;
 }

--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
     </div>
   </div>
 
+  <div id="music-overlay" class="music-overlay"></div>
+
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,17 +1,30 @@
+const bagColor = 'linear-gradient(135deg, #eeeeee, #ffffff)';
+
 const bagsInfo = [
-  {title: 'Bag Cenario 1', color: 'linear-gradient(135deg, #444, #777)', items: ['barra1_palco.png','barra2_palco.png','barra3_palco.png','barra4_palco.png']},
-  {title: 'Bag Cenario 2', color: 'linear-gradient(135deg, #444, #777)', items: ['barra5_palco.png','barra6_palco.png','barra7_palco.png','barra8_palco.png']},
-  {title: 'Bag Cenario 3', color: 'linear-gradient(135deg, #444, #777)', items: ['barra9_palco.png','barra10_palco.png','barra11_palco.png','barra12_palco.png']},
-  {title: 'Bag Cenario 4', color: 'linear-gradient(135deg, #444, #777)', items: ['barra13_palco.png','barra14_palco.png','barra15_palco.png','barra16_palco.png']},
-  {title: 'Bag Stella', color: 'linear-gradient(135deg, #e91e63, #ff80ab)', items: ['blusa_stella.png','jaleco_stella.png','maquiagem_stella.png','meia1_stella.png','meia2_stella.png','peruca_stella.png','saia_stella.png','sapato1_stella.png','sapato2_stella.png']},
-  {title: 'Bag WJ', color: 'linear-gradient(135deg, #f00, #ffeb3b)', items: ['calça wj.png','colete_wj.png','luva_wj.png','mascara wj.png','sapatos_wj.png']},
-  {title: 'Bag Professor Xuxu', color: 'linear-gradient(135deg, #ff9800, #2196f3)', items: ['boina_professor.png','oculos_professor.png','calça_professor.png','camisa_professor.png','jaleco_professor.png','luva1_professor.png','luva2_professor.png','sapato1_professor.png','sapato2_professor.png']},
-  {title: 'Bag 08', color: 'linear-gradient(135deg, #673ab7, #ffd700)', items: ['extensao_palco.png','laser1_palco.png','laser2_palco.png','laser3_palco.png','laser4_palco.png','laser_palco.png','setlight1_palco.png','setlight2_palco.png','setlight3_palco.png']}
+  {title: 'Bag Cenario 1', items: ['barra1_palco.png','barra2_palco.png','barra3_palco.png','barra4_palco.png']},
+  {title: 'Bag Cenario 2', items: ['barra5_palco.png','barra6_palco.png','barra7_palco.png','barra8_palco.png']},
+  {title: 'Bag Cenario 3', items: ['barra9_palco.png','barra10_palco.png','barra11_palco.png','barra12_palco.png']},
+  {title: 'Bag Cenario 4', items: ['barra13_palco.png','barra14_palco.png','barra15_palco.png','barra16_palco.png']},
+  {title: 'Bag Stella', items: ['blusa_stella.png','jaleco_stella.png','maquiagem_stella.png','meia1_stella.png','meia2_stella.png','peruca_stella.png','saia_stella.png','sapato1_stella.png','sapato2_stella.png']},
+  {title: 'Bag WJ', items: ['calça wj.png','colete_wj.png','luva_wj.png','mascara wj.png','sapatos_wj.png']},
+  {title: 'Bag Professor Xuxu', items: ['boina_professor.png','oculos_professor.png','calça_professor.png','camisa_professor.png','jaleco_professor.png','luva1_professor.png','luva2_professor.png','sapato1_professor.png','sapato2_professor.png']},
+  {title: 'Bag 08', items: ['extensao_palco.png','laser1_palco.png','laser2_palco.png','laser3_palco.png','laser4_palco.png','laser_palco.png','setlight1_palco.png','setlight2_palco.png','setlight3_palco.png']}
+];
+
+const musicList = [
+  {title: 'Mundo colorido', file: 'Mundo colorido.mp3'},
+  {title: 'Casinha do coração', file: 'Casinha do coração.mp3'},
+  {title: 'Você é especial', file: 'Você é especial.mp3'},
+  {title: 'Fábrica de heróis', file: 'Fábrica de Heróis.mp3'},
+  {title: 'Você não é todo mundo', file: 'Você não é todo mundo.mp3'},
+  {title: 'Eu vim aqui para adorar', file: 'Eu vim aqui para adorar.mp3'}
 ];
 
 let checkedItemsPerBag = bagsInfo.map(() => new Set());
 let currentBagIndex = null;
 let currentPage = 0;
+let toggleTracker = {};
+let currentAudio = null;
 
 function renderPage() {
   const container = document.getElementById('bags-page');
@@ -25,9 +38,9 @@ function renderPage() {
 
     const bagDiv = document.createElement('div');
     bagDiv.className = 'bag';
-    bagDiv.style.background = bag.color;
+    bagDiv.style.background = bagColor;
     bagDiv.innerText = bag.title;
-    bagDiv.onclick = () => openBag(bag.title, globalIndex, bag.items, bag.color);
+    bagDiv.onclick = () => openBag(bag.title, globalIndex, bag.items);
     wrapper.appendChild(bagDiv);
 
     const progress = document.createElement('div');
@@ -64,10 +77,10 @@ document.addEventListener('touchend', e => {
   if (touchEndX > touchStartX + 50) prevPage();
 });
 
-function openBag(title, bagIndex, items, bgColor) {
+function openBag(title, bagIndex, items) {
   document.getElementById('modal').style.display = 'flex';
   const modalContent = document.getElementById('modal-content');
-  modalContent.style.background = bgColor;
+  modalContent.style.background = bagColor;
   document.getElementById('bag-title').innerText = title;
   let listHTML = '';
   currentBagIndex = bagIndex;
@@ -90,6 +103,18 @@ function closeBag(event) {
 }
 
 function toggleItem(index) {
+  const key = currentBagIndex + '-' + index;
+  const now = Date.now();
+  if (toggleTracker[key] && now - toggleTracker[key].start < 5000) {
+    toggleTracker[key].count++;
+  } else {
+    toggleTracker[key] = { count: 1, start: now };
+  }
+  if (toggleTracker[key] && toggleTracker[key].count >= 3) {
+    toggleTracker[key] = null;
+    showMusicOverlay();
+  }
+
   const itemElement = document.getElementById(`item-${index}`);
   if (checkedItemsPerBag[currentBagIndex].has(index)) {
     checkedItemsPerBag[currentBagIndex].delete(index);
@@ -97,6 +122,7 @@ function toggleItem(index) {
   } else {
     checkedItemsPerBag[currentBagIndex].add(index);
     itemElement.classList.add('checked');
+    new Audio('Songs/Sucesso.mp3').play();
   }
   updateProgress();
 }
@@ -117,6 +143,95 @@ function updateProgress() {
   });
   const globalPercent = (totalChecked / totalItems) * 100;
   document.getElementById('global-progress-bar').style.width = globalPercent + '%';
+}
+
+function disableAllButtons(disable) {
+  document.querySelectorAll('button').forEach(btn => btn.disabled = disable);
+  document.querySelectorAll('.bag, .boxmusic').forEach(el => {
+    el.style.pointerEvents = disable ? 'none' : 'auto';
+  });
+}
+
+function buildMusicOverlay() {
+  const overlay = document.getElementById('music-overlay');
+  overlay.innerHTML = '';
+  musicList.forEach((m, i) => {
+    const box = document.createElement('div');
+    box.className = 'boxmusic';
+    box.innerText = m.title;
+    box.addEventListener('click', () => playMusic(i));
+    const progress = document.createElement('div');
+    progress.className = 'music-progress';
+    progress.innerHTML = `<div class="music-progress-bar" id="music-progress-${i}"></div>`;
+    box.appendChild(progress);
+    overlay.appendChild(box);
+  });
+  overlay.dataset.built = 'true';
+  overlay.addEventListener('click', e => {
+    if (e.target.id === 'music-overlay') hideMusicOverlay();
+  });
+}
+
+function showMusicOverlay() {
+  const overlay = document.getElementById('music-overlay');
+  if (!overlay.dataset.built) buildMusicOverlay();
+  overlay.style.display = 'flex';
+}
+
+function hideMusicOverlay() {
+  const overlay = document.getElementById('music-overlay');
+  overlay.style.display = 'none';
+}
+
+function playMusic(idx) {
+  if (currentAudio) {
+    currentAudio.pause();
+  }
+  const music = musicList[idx];
+  currentAudio = new Audio('Songs/' + encodeURIComponent(music.file));
+  const progressBar = document.getElementById(`music-progress-${idx}`);
+  document.querySelectorAll('.music-progress-bar').forEach(bar => bar.style.width = '0%');
+  currentAudio.addEventListener('timeupdate', () => {
+    const pct = (currentAudio.currentTime / currentAudio.duration) * 100;
+    progressBar.style.width = pct + '%';
+  });
+  currentAudio.addEventListener('ended', () => {
+    disableAllButtons(false);
+  });
+  disableAllButtons(true);
+  currentAudio.play();
+}
+
+let tapCount = 0;
+let tapTimer = null;
+document.addEventListener('click', () => {
+  tapCount++;
+  if (tapTimer) clearTimeout(tapTimer);
+  tapTimer = setTimeout(() => { tapCount = 0; }, 1000);
+  if (tapCount >= 5 && currentAudio) {
+    fadeOutCurrentAudio();
+    tapCount = 0;
+  }
+});
+
+function fadeOutCurrentAudio() {
+  if (!currentAudio) return;
+  const audio = currentAudio;
+  const startVolume = audio.volume;
+  const duration = 3000;
+  const step = 50;
+  const decrement = startVolume / (duration / step);
+  const interval = setInterval(() => {
+    if (audio.volume - decrement > 0) {
+      audio.volume -= decrement;
+    } else {
+      audio.volume = 0;
+      clearInterval(interval);
+      audio.pause();
+      audio.volume = startVolume;
+      disableAllButtons(false);
+    }
+  }, step);
 }
 
 // Initial render


### PR DESCRIPTION
## Summary
- Apply light gray to white gradients to app background and bag boxes
- Play success sound when checking items and add music overlay unlocked by rapid toggles
- Include six song boxes with progress bars, global button disabling and tap-triggered fade-out pause

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7df22aca083258531bf6ad144aa35