### PR TITLE
Lock UI during music playback

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -173,8 +173,8 @@ h1 {
 }
 
 .boxmusic {
-  background: linear-gradient(135deg, #eeeeee, #ffffff);
-  opacity: 0.75;
+  background: blue;
+  opacity: 1;
   padding: 20px;
   border-radius: 12px;
   cursor: pointer;
@@ -182,6 +182,10 @@ h1 {
   color: black;
   width: 80%;
   max-width: 300px;
+}
+
+.boxmusic.playing {
+  background: green;
 }
 
 .music-progress {


### PR DESCRIPTION
## Summary
- prevent closing music overlay while a song plays
- color music boxes blue and highlight playing box in green
- require five taps within three seconds to stop playback

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7e53fb01083258c39f48b9760f4b7