### PR TITLE
Centralize item modal and progress bar with blue theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,7 +1,8 @@
 body {
-  background: linear-gradient(#eeeeee, #ffffff);
-  color: black;
+  background: linear-gradient(135deg, #155fe8, #5588ff);
+  color: #333;
   font-family: 'Open Sans', sans-serif;
+  font-weight: 700;
   margin: 0;
   padding: 0;
   text-align: center;
@@ -39,7 +40,7 @@ h1 {
   padding: 15px;
   cursor: pointer;
   font-weight: bold;
-  color: black;
+  color: #333;
   width: 100%;
   background: linear-gradient(135deg, #eeeeee, #ffffff);
 }
@@ -80,8 +81,12 @@ h1 {
   width: 80%;
   max-width: 600px;
   text-align: center;
-  color: black;
+  color: #333;
   background: linear-gradient(135deg, #eeeeee, #ffffff);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: auto;
 }
 
 #items-list {
@@ -89,14 +94,16 @@ h1 {
   grid-template-columns: repeat(3, 1fr);
   gap: 10px;
   justify-items: center;
+  margin: 0 auto;
 }
 
-#items-list img {
+.item-img {
   width: 100%;
   max-width: 100px;
   opacity: 0.5;
   transition: opacity 0.3s;
   cursor: pointer;
+  animation: fadeIn 0.5s ease;
 }
 
 .checked {
@@ -110,6 +117,12 @@ h1 {
   width: 100%;
   padding: 10px;
   background: linear-gradient(#eeeeee, #ffffff);
+  display: flex;
+  justify-content: center;
+}
+
+.progress-footer .progress {
+  width: 80%;
 }
 
 .progress {
@@ -173,19 +186,19 @@ h1 {
 }
 
 .boxmusic {
-  background: blue;
+  background: #155fe8;
   opacity: 1;
   padding: 20px;
   border-radius: 12px;
   cursor: pointer;
   font-weight: bold;
-  color: black;
+  color: #fff;
   width: 80%;
   max-width: 300px;
 }
 
 .boxmusic.playing {
-  background: green;
+  background: #0e4cb8;
 }
 
 .music-progress {
@@ -201,4 +214,15 @@ h1 {
   height: 100%;
   background: green;
   width: 0%;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/index.html
+++ b/index.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Logística - Turma do Printy</title>
-  <link rel="stylesheet" href="css/style.css" />
-</head>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Logística - Turma do Printy</title>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
 <body>
   <h1>📦 Bags da Turma do Printy</h1>
 

--- a/js/app.js
+++ b/js/app.js
@@ -89,7 +89,7 @@ function openBag(title, bagIndex, items) {
   items.forEach((item, i) => {
     const checked = checkedItemsPerBag[bagIndex].has(i);
     const src = `Imagens/${folder}/${encodeURIComponent(item)}`;
-    listHTML += `<img id="item-${i}" class="${checked ? 'checked' : ''}" onclick="toggleItem(${i})" src="${src}" alt="item" />`;
+    listHTML += `<img id="item-${i}" class="item-img ${checked ? 'checked' : ''}" onclick="toggleItem(${i})" src="${src}" alt="item" />`;
   });
 
   document.getElementById('items-list').innerHTML = listHTML;


### PR DESCRIPTION
## Summary
- center modal item box and global progress bar
- add fade-in animation for items and blue theme styling
- style music selection boxes with brand blue and white text

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/bags/package.json')

------
https://chatgpt.com/codex/tasks/task_e_68a7e84b31a48325a9be5e3d53b2412a