### PR TITLE
Revamp mobile layout and persist bag progress

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -58,7 +58,6 @@ h1 {
   height: 100%;
   background: green;
   width: 0%;
-  transition: width 0.3s;
 }
 
 .modal {
@@ -86,6 +85,7 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   margin: auto;
 }
 
@@ -101,9 +101,7 @@ h1 {
   width: 100%;
   max-width: 100px;
   opacity: 0.5;
-  transition: opacity 0.3s;
   cursor: pointer;
-  animation: fadeIn 0.5s ease;
 }
 
 .checked {
@@ -138,7 +136,6 @@ h1 {
   height: 100%;
   background: blue;
   width: 0%;
-  transition: width 0.3s;
 }
 
 .nav-buttons {
@@ -216,13 +213,4 @@ h1 {
   width: 0%;
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
+

--- a/index.html
+++ b/index.html
@@ -7,9 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css" />
   </head>
-<body>
-  <h1>📦 Bags da Turma do Printy</h1>
-
+<body style="display:none;">
   <div id="bags-page" class="bags-container"></div>
   <div class="nav-buttons">
     <button onclick="prevPage()">⬅️ Anterior</button>


### PR DESCRIPTION
## Summary
- Remove header and mobile animations, center item selection box, and hide app until assets load
- Persist bag item progress using localStorage and preload all images and music before init
- Add four new bags: bag bit, bag byte, bag gerente, and bag duque maldoso

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a838afb7c08325a7f498ccb98cf753