### PR TITLE
fix: keep product modal centered

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,7 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 body {
   background: linear-gradient(135deg, #155fe8, #5588ff);
   color: #333;


### PR DESCRIPTION
## Summary
- ensure padding doesn't push product modal off screen by using global border-box sizing

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a846047834832598da31359b329564