### PR TITLE
feat: long-press playback and toggled song reordering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -225,4 +225,14 @@ h1 {
   width: 0%;
 }
 
+@keyframes flash-green {
+  0% { background: #155fe8; }
+  50% { background: #00ff00; }
+  100% { background: #155fe8; }
+}
+
+.boxmusic.flash {
+  animation: flash-green 0.3s;
+}
+
 


### PR DESCRIPTION
## Summary
- allow navigating additional songs by swiping right
- support long-press to start playback with green flash
- add secret sequence to disable or enable reordering on triple tap

## Testing
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8ab4799e48325924d4714308e8d7f