### PR TITLE
Refine music overlay gradients and controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,9 @@
 *, *::before, *::after {
   box-sizing: border-box;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
 }
 
 body {
@@ -191,11 +195,11 @@ h1 {
   align-items: center;
   justify-content: center;
   gap: 20px;
-  background: rgba(255, 255, 255, 0.95);
+  background: linear-gradient(#ffffff, #cccccc);
 }
 
 .boxmusic {
-  background: #155fe8;
+  background: linear-gradient(#155fe8, #4a90ff);
   opacity: 1;
   padding: 20px;
   border-radius: 12px;
@@ -207,7 +211,7 @@ h1 {
 }
 
 .boxmusic.playing {
-  background: #0e4cb8;
+  background: linear-gradient(#0e4cb8, #3470d4);
 }
 
 .music-progress {
@@ -226,9 +230,9 @@ h1 {
 }
 
 @keyframes flash-green {
-  0% { background: #155fe8; }
+  0% { background: linear-gradient(#155fe8, #4a90ff); }
   50% { background: #00ff00; }
-  100% { background: #155fe8; }
+  100% { background: linear-gradient(#155fe8, #4a90ff); }
 }
 
 .boxmusic.flash {

--- a/js/app.js
+++ b/js/app.js
@@ -48,6 +48,11 @@ let bagItems = [];
 let currentItemPage = 0;
 let currentBagItems = [];
 
+document.addEventListener('copy', e => e.preventDefault());
+document.addEventListener('cut', e => e.preventDefault());
+document.addEventListener('paste', e => e.preventDefault());
+document.addEventListener('contextmenu', e => e.preventDefault());
+
 function renderPage() {
   const container = document.getElementById('bags-page');
   container.innerHTML = '';
@@ -337,17 +342,14 @@ function renderMusicOverlay() {
 function showMusicOverlay() {
   const overlay = document.getElementById('music-overlay');
   if (!overlay.dataset.init) {
-    overlay.addEventListener('click', e => {
-      if (!currentAudio && e.target.id === 'music-overlay') hideMusicOverlay();
-    });
     overlay.addEventListener('touchstart', e => {
       musicTouchStartX = e.changedTouches[0].screenX;
     });
     overlay.addEventListener('touchend', e => {
       const endX = e.changedTouches[0].screenX;
-      // deslize para a direita para acessar a próxima página de músicas
-      if (endX > musicTouchStartX + 50) nextMusicPage();
-      if (endX < musicTouchStartX - 50) prevMusicPage();
+      // deslize para a esquerda para acessar a próxima página de músicas
+      if (endX < musicTouchStartX - 50) nextMusicPage();
+      if (endX > musicTouchStartX + 50) prevMusicPage();
     });
     overlay.dataset.init = 'true';
   }


### PR DESCRIPTION
## Summary
- Add white-to-gray gradient background and lighter blue gradients for music boxes
- Disable tap-to-close, block copy/paste and invert swipe navigation on music overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b070ea3083258c89511b3aea7682