### PR TITLE
Implement loader, navigation menu, and item actions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,7 @@ body {
   height: 100vh;
   display: flex;
   flex-direction: column;
+  animation: fadeIn 0.5s ease;
 }
 
 h1 {
@@ -51,6 +52,11 @@ h1 {
   color: #fff;
   width: 100%;
   background: linear-gradient(135deg, #000000, #4F4F4F);
+  transition: transform 0.3s, opacity 0.3s;
+}
+
+.bag:hover {
+  transform: scale(1.02);
 }
 
 .bag-progress {
@@ -167,6 +173,12 @@ h1 {
   border-radius: 8px;
   cursor: pointer;
   font-weight: bold;
+  transition: background 0.3s, transform 0.3s;
+}
+
+.nav-buttons button:hover {
+  background: rgba(255,255,255,0.2);
+  transform: scale(1.05);
 }
 
 @media (min-width: 601px) {
@@ -196,6 +208,8 @@ h1 {
   justify-content: center;
   gap: 20px;
   background: linear-gradient(#ffffff, #cccccc);
+  opacity: 0;
+  transition: opacity 0.3s;
 }
 
 .boxmusic {
@@ -208,10 +222,15 @@ h1 {
   color: #fff;
   width: 80%;
   max-width: 300px;
+  transition: transform 0.3s;
 }
 
 .boxmusic.playing {
   background: linear-gradient(#0e4cb8, #3470d4);
+}
+
+.boxmusic:hover {
+  transform: scale(1.02);
 }
 
 .music-progress {
@@ -237,6 +256,131 @@ h1 {
 
 .boxmusic.flash {
   animation: flash-green 0.3s;
+}
+
+.main-header {
+  background: rgba(0,0,0,0.2);
+  display: flex;
+  justify-content: center;
+  backdrop-filter: blur(5px);
+}
+
+.main-header ul {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+  padding: 10px;
+  margin: 0;
+}
+
+.main-header button {
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-weight: bold;
+  cursor: pointer;
+  padding: 8px 16px;
+  border-radius: 8px;
+  transition: background 0.3s, transform 0.3s;
+}
+
+.main-header button:hover {
+  background: rgba(255,255,255,0.2);
+  transform: scale(1.05);
+}
+
+.items-overlay,
+.item-action-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.8);
+  color: #fff;
+  flex-direction: column;
+  opacity: 0;
+  transition: opacity 0.3s;
+  z-index: 1000;
+}
+
+.items-overlay .flagged-item {
+  margin: 5px 0;
+}
+
+.item-action-menu .menu-box {
+  background: #fff;
+  color: #000;
+  padding: 20px;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.item-action-menu button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.loader-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(#40e0d0, #008080);
+  z-index: 2000;
+  flex-direction: column;
+  color: #fff;
+}
+
+.loader-circle {
+  position: relative;
+  width: 150px;
+  height: 150px;
+}
+
+.loader-circle svg {
+  transform: rotate(-90deg);
+  width: 150px;
+  height: 150px;
+}
+
+.loader-circle circle {
+  stroke: #fff;
+  stroke-width: 20;
+  fill: none;
+  stroke-dasharray: 345;
+  stroke-dashoffset: 345;
+  transition: stroke-dashoffset 0.3s;
+}
+
+.loader-circle span {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.fade {
+  animation: fadeIn 0.5s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,18 @@
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css" />
   </head>
-<body style="display:none;">
+<body>
+  <header class="main-header fade">
+    <nav>
+      <ul>
+        <li><button id="menu-items">Itens</button></li>
+        <li><button id="menu-music">Músicas</button></li>
+        <li><button id="menu-bags">Bags</button></li>
+        <li><button id="menu-more">Mais</button></li>
+      </ul>
+    </nav>
+  </header>
+
   <div id="bags-page" class="bags-container"></div>
   <div class="nav-buttons">
     <button onclick="prevPage()">⬅️ Anterior</button>
@@ -31,6 +42,22 @@
   </div>
 
   <div id="music-overlay" class="music-overlay"></div>
+  <div id="items-overlay" class="items-overlay"></div>
+  <div id="item-action-menu" class="item-action-menu">
+    <div class="menu-box">
+      <button onclick="selectItemAction('lavar')">Lavar</button>
+      <button onclick="selectItemAction('consertar')">Consertar</button>
+    </div>
+  </div>
+  <div id="loader-overlay" class="loader-overlay">
+    <div class="loader-circle">
+      <svg width="150" height="150">
+        <circle cx="75" cy="75" r="55" />
+      </svg>
+      <span id="loader-text">0%</span>
+      <div id="loader-mb"></div>
+    </div>
+  </div>
 
   <script src="js/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Add header navigation with Itens, Músicas, Bags and Mais
- Introduce loader with circular progress for caching assets
- Support long-press item actions and six-tap music menu access

## Testing
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8c113c2f483258870d6c8e49a672a