### PR TITLE
Improve music interactions and link correct audio files

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -212,6 +212,10 @@ h1 {
   transition: opacity 0.3s;
 }
 
+.music-overlay.locked {
+  background: linear-gradient(#ffffff, #cce5ff);
+}
+
 .boxmusic {
   background: linear-gradient(#155fe8, #4a90ff);
   opacity: 1;


### PR DESCRIPTION
## Summary
- Map song titles to correct mp3 filenames
- Require double tap to move song up with success sound and flash
- Add long-press progress bar and lock sequence visual feedback

## Testing
- `node --check js/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ee6a21fc83258ce7d55fdd1083ca