### PR TITLE
Adjust layout for specific item counts and add cascade animations

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -130,6 +130,26 @@ h1 {
   opacity: 1;
 }
 
+#items-list.grid-3x2 {
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  justify-items: center;
+  align-items: center;
+}
+
+#items-list.grid-2x2 {
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  justify-items: center;
+  align-items: center;
+}
+
+#items-list.grid-3x2 .item-img,
+#items-list.grid-2x2 .item-img {
+  width: 140%;
+  height: 140%;
+}
+
 .progress-footer {
   position: fixed;
   bottom: 0;
@@ -422,6 +442,16 @@ h1 {
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }
+}
+
+@keyframes cascade {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.cascade {
+  opacity: 0;
+  animation: cascade 0.5s ease forwards;
 }
 
 

--- a/js/app.js
+++ b/js/app.js
@@ -73,7 +73,8 @@ function renderPage() {
   bagsInfo.slice(start, end).forEach((bag, idx) => {
     const globalIndex = start + idx;
     const wrapper = document.createElement('div');
-    wrapper.className = 'bag-wrapper';
+    wrapper.className = 'bag-wrapper cascade';
+    wrapper.style.animationDelay = `${idx * 0.1}s`;
 
     const bagDiv = document.createElement('div');
     bagDiv.className = 'bag';
@@ -158,6 +159,13 @@ function renderItems() {
   const folder = encodeURIComponent(bagsInfo[currentBagIndex].title);
   const list = document.getElementById('items-list');
   list.innerHTML = '';
+  list.classList.remove('grid-3x2', 'grid-2x2');
+  const total = currentBagItems.length;
+  if (total === 4) {
+    list.classList.add('grid-2x2');
+  } else if (total === 5 || total === 6) {
+    list.classList.add('grid-3x2');
+  }
   for (let i = start; i < end; i++) {
     const item = currentBagItems[i];
     const checked = checkedItemsPerBag[currentBagIndex].has(i);
@@ -166,7 +174,8 @@ function renderItems() {
     img.id = `item-${i}`;
     img.src = src;
     img.alt = 'item';
-    img.className = `item-img ${checked ? 'checked' : ''}`;
+    img.className = `item-img ${checked ? 'checked' : ''} cascade`;
+    img.style.animationDelay = `${(i - start) * 0.1}s`;
 
     let longPress = false;
     const startPress = () => {
@@ -455,7 +464,8 @@ function renderMusicOverlay() {
   musicList.slice(start, end).forEach((title, i) => {
     const idx = start + i;
     const box = document.createElement('div');
-    box.className = 'boxmusic';
+    box.className = 'boxmusic cascade';
+    box.style.animationDelay = `${i * 0.1}s`;
     box.id = `music-box-${idx}`;
     box.innerText = title;
 
@@ -536,14 +546,17 @@ function hideMusicOverlay() {
 function showItemsOverlay() {
   const overlay = document.getElementById('items-overlay');
   overlay.innerHTML = '';
-  Object.keys(itemStatus).forEach(key => {
+  Object.keys(itemStatus).forEach((key, idx) => {
     const [bagIdx, itemIdx] = key.split('-').map(Number);
     const container = document.createElement('div');
-    container.className = 'flagged-item';
+    container.className = 'flagged-item cascade';
+    container.style.animationDelay = `${idx * 0.1}s`;
     const folder = encodeURIComponent(bagsInfo[bagIdx].title);
     const img = document.createElement('img');
     img.src = `Imagens/${folder}/${encodeURIComponent(bagItems[bagIdx][itemIdx])}`;
     img.alt = 'item';
+    img.classList.add('cascade');
+    img.style.animationDelay = `${idx * 0.1}s`;
     container.appendChild(img);
     const btn = document.createElement('button');
     const action = itemStatus[key];


### PR DESCRIPTION
## Summary
- Support dynamic grids for small bags: 5–6 items use a 3x2 layout and 4 items use 2x2, with icons enlarged by 40%
- Introduce a reusable cascade animation and apply it to bag wrappers, item images, music boxes, and flagged item overlays

## Testing
- ✅ `node --check js/app.js`
- ⚠️ `npm test` *(missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a9051989dc8325a08f3d6f20c169f3