### PR TITLE
Adjust item icon sizing and restore selection

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -122,7 +122,7 @@ h1 {
   max-width: none;
   height: 100%;
   object-fit: contain;
-  opacity: 0.5;
+  opacity: 0.8;
   cursor: pointer;
 }
 
@@ -135,6 +135,8 @@ h1 {
   grid-template-rows: repeat(3, 1fr);
   justify-items: center;
   align-items: center;
+  justify-content: center;
+  align-content: center;
 }
 
 #items-list.grid-2x2 {
@@ -142,12 +144,15 @@ h1 {
   grid-template-rows: repeat(2, 1fr);
   justify-items: center;
   align-items: center;
+  justify-content: center;
+  align-content: center;
 }
 
 #items-list.grid-3x2 .item-img,
 #items-list.grid-2x2 .item-img {
-  width: 140%;
-  height: 140%;
+  width: 119%;
+  height: 119%;
+  margin: auto;
 }
 
 .progress-footer {

--- a/js/app.js
+++ b/js/app.js
@@ -176,6 +176,7 @@ function renderItems() {
     img.alt = 'item';
     img.className = `item-img ${checked ? 'checked' : ''} cascade`;
     img.style.animationDelay = `${(i - start) * 0.1}s`;
+    img.style.opacity = checked ? '1' : '0.8';
 
     let longPress = false;
     const startPress = () => {
@@ -239,12 +240,15 @@ function toggleItem(index) {
   }
 
   const itemElement = document.getElementById(`item-${index}`);
-  if (checkedItemsPerBag[currentBagIndex].has(index)) {
-    checkedItemsPerBag[currentBagIndex].delete(index);
+  const set = checkedItemsPerBag[currentBagIndex] || (checkedItemsPerBag[currentBagIndex] = new Set());
+  if (set.has(index)) {
+    set.delete(index);
     itemElement.classList.remove('checked');
+    itemElement.style.opacity = '0.8';
   } else {
-    checkedItemsPerBag[currentBagIndex].add(index);
+    set.add(index);
     itemElement.classList.add('checked');
+    itemElement.style.opacity = '1';
     new Audio('Songs/Sucesso.mp3').play();
   }
   saveProgress();


### PR DESCRIPTION
## Summary
- shrink icons by 15% and center grid on 4–6 item screens
- start items at 80% opacity and brighten on tap
- ensure item selection updates progress

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d4d2e8ac832592aacef86e30afc9